### PR TITLE
Adding the application listeners to early set, if it's empty.

### DIFF
--- a/spring-context/src/main/java/org/springframework/context/support/AbstractApplicationContext.java
+++ b/spring-context/src/main/java/org/springframework/context/support/AbstractApplicationContext.java
@@ -604,7 +604,7 @@ public abstract class AbstractApplicationContext extends DefaultResourceLoader
 		getEnvironment().validateRequiredProperties();
 
 		// Store pre-refresh ApplicationListeners...
-		if (this.earlyApplicationListeners == null) {
+		if (this.earlyApplicationListeners == null || this.earlyApplicationListeners.isEmpty()) {
 			this.earlyApplicationListeners = new LinkedHashSet<>(this.applicationListeners);
 		}
 		else {
@@ -1035,7 +1035,7 @@ public abstract class AbstractApplicationContext extends DefaultResourceLoader
 			onClose();
 
 			// Reset local application listeners to pre-refresh state.
-			if (this.earlyApplicationListeners != null) {
+			if (this.earlyApplicationListeners != null && !this.earlyApplicationListeners.isEmpty()) {
 				this.applicationListeners.clear();
 				this.applicationListeners.addAll(this.earlyApplicationListeners);
 			}


### PR DESCRIPTION
Don't loose the application listeners, if early set was empty.
I have the following problem: on the application startup there is a call of prepareRefresh(), so it works like that

this.earlyApplicationListeners = new LinkedHashSet<>(this.applicationListeners);

There are this.applicationListeners is an empty collection.
Then it's needed to refresh the Application Context, so it provokes the refresh() at AbstractApplicationContext, then goes to prepareRefresh and then checks

this.earlyApplicationListeners == null,

but it's an empty LinkedHashSet, not null, so then it comes to
this.applicationListeners.clear();
and all the listeners are removed, but this collection is not empty, so I'm loosing all of applicationListeners there.

The application listeners collection was modified by CXF transports (https://github.com/apache/cxf/blob/ec4423437bd7d6b63e3464761394cfafb50cacfa/rt/transports/http/src/main/java/org/apache/cxf/transport/servlet/CXFServlet.java#L90)
